### PR TITLE
Preserve External Links from InfoWindow

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -75,11 +75,21 @@ def configure_routes(app):
 def _get_content_from_site(url):
     page = requests.get(url)
     soup = BeautifulSoup(page.content, "html.parser")
+
+    # dokuwiki__content is assumed to have the main content of the article
     content = soup.find("div", {"id": "dokuwiki__content"})
-    content.find("div", {"class": "pageId"}).decompose()
-    results = content.findAll("a", {"href": True})
-    for link in results:
-        link["href"] = f"https://cwsl.ca{link['href']}"
+
+    # Remove the pageID from the displayed article
+    page_id = content.find("div", {"class": "pageId"})
+    if page_id is not None:
+        page_id.decompose()
+
+    anchors = content.findAll("a", {"href": True})
+    for anchor in anchors:
+        # Prepend https://cwsl.ca to all links which were local links within cwsl
+        if len(anchor["href"]) > 0 and anchor["href"][0] == "/":
+            anchor["href"] = f"https://cwsl.ca{anchor['href']}"
+
     return str(content)
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -72,12 +72,16 @@ def configure_routes(app):
         return response
 
 
-def _get_content_from_site(url):
+def _get_content_from_site(url: str) -> str:
     page = requests.get(url)
+    if not page.ok:
+        return f"No additional information available for the topic - {page.status}"
     soup = BeautifulSoup(page.content, "html.parser")
 
     # dokuwiki__content is assumed to have the main content of the article
     content = soup.find("div", {"id": "dokuwiki__content"})
+    if content is None:
+        return "Error when showing article preview"
 
     # Remove the pageID from the displayed article
     page_id = content.find("div", {"class": "pageId"})

--- a/backend/server.py
+++ b/backend/server.py
@@ -86,7 +86,7 @@ def _get_content_from_site(url):
 
     anchors = content.findAll("a", {"href": True})
     for anchor in anchors:
-        # Prepend https://cwsl.ca to all links which were local links within cwsl
+        # Prepend https://cwsl.ca to all links which were previously local links
         if len(anchor["href"]) > 0 and anchor["href"][0] == "/":
             anchor["href"] = f"https://cwsl.ca{anchor['href']}"
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -75,8 +75,7 @@ def configure_routes(app):
 def _get_content_from_site(url):
     page = requests.get(url)
     soup = BeautifulSoup(page.content, "html.parser")
-    content = soup.find_all(["h1", "h2", "p"])
-    return "\n".join([c.text for c in content])
+    return str(soup)
 
 
 if __name__ == "__main__":

--- a/backend/server.py
+++ b/backend/server.py
@@ -77,6 +77,9 @@ def _get_content_from_site(url):
     soup = BeautifulSoup(page.content, "html.parser")
     content = soup.find("div", {"id": "dokuwiki__content"})
     content.find("div", {"class": "pageId"}).decompose()
+    results = content.findAll("a", {"href": True})
+    for link in results:
+        link["href"] = f"https://cwsl.ca{link['href']}"
     return str(content)
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -75,7 +75,9 @@ def configure_routes(app):
 def _get_content_from_site(url):
     page = requests.get(url)
     soup = BeautifulSoup(page.content, "html.parser")
-    return str(soup)
+    content = soup.find("div", {"id": "dokuwiki__content"})
+    content.find("div", {"class": "pageId"}).decompose()
+    return str(content)
 
 
 if __name__ == "__main__":

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5499,6 +5499,11 @@
         "domelementtype": "1"
       }
     },
+    "dompurify": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
     "d3": "^6.3.1",
+    "dompurify": "^2.2.6",
     "fontsource-roboto": "^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/frontend/src/components/InfoWindow/InfoWindow.jsx
+++ b/frontend/src/components/InfoWindow/InfoWindow.jsx
@@ -1,6 +1,8 @@
 /**
  * The react component for the information window for each node
  * in the concept tree.
+ * Note: dangerouslySetInnerHTML property used here becomes safe if
+ * sanitization is done to the incoming htmlInfo using DOMPurify
  */
 
 import React from "react";

--- a/frontend/src/components/InfoWindow/InfoWindow.jsx
+++ b/frontend/src/components/InfoWindow/InfoWindow.jsx
@@ -4,12 +4,17 @@
  */
 
 import React from "react";
+import DOMPurify from "dompurify";
 
 export const InfoWindow = ({ info }) => {
+  const safeHTML = DOMPurify.sanitize(info);
   return (
     <div>
       <h2>Wiki Information</h2>
-      <p>{info}</p>
+      <div
+        id="infoWindowDiv"
+        dangerouslySetInnerHTML={{ __html: safeHTML }}
+      ></div>
     </div>
   );
 };


### PR DESCRIPTION
- This MR preserves the external links from a node's article by fetching the HTML of the page itself rather than just the text. 
- Completes https://github.com/orgs/VerWiki/projects/1#card-53430519